### PR TITLE
fix(useMedia): replacing deprecated event listeners

### DIFF
--- a/src/useMedia.ts
+++ b/src/useMedia.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { isBrowser } from './misc/util';
+import { isBrowser, off, on } from './misc/util';
 
 const getInitialState = (query: string, defaultState?: boolean) => {
   // Prevent a React hydration mismatch when a default value is provided by not defaulting to window.matchMedia(query).matches.
@@ -27,16 +27,19 @@ const useMedia = (query: string, defaultState?: boolean) => {
   useEffect(() => {
     let mounted = true;
     const mql = window.matchMedia(query);
-
-    mql.onchange = (e) => {
-      if (!mounted) return;
-      setState(e.matches);
+    const onChange = () => {
+      if (!mounted) {
+        return;
+      }
+      setState(!!mql.matches);
     };
 
+    on(mql, 'change', onChange);
     setState(mql.matches);
 
     return () => {
       mounted = false;
+      off(mql, 'change', onChange);
     };
   }, [query]);
 


### PR DESCRIPTION
Just replace addListener(onChange) with addEventListener('change', onChange) instead of using mql.onChange.

# Description

<!-- Please include a summary of the change along with relevant motivation and context. -->


## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [ ] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [ ] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [ ] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [ ] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [ ] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
